### PR TITLE
Add type-checks to getInfo, getDirectoryItems and getDirectoryItemsInfo

### DIFF
--- a/nativefs.lua
+++ b/nativefs.lua
@@ -351,6 +351,9 @@ local function withTempMount(dir, fn, ...)
 end
 
 function nativefs.getDirectoryItems(dir)
+	if type(dir) ~= "string" then
+		error("bad argument #1 to 'getDirectoryItems' (string expected, got " .. type(dir) .. ")")
+	end
 	local result, err = withTempMount(dir, love.filesystem.getDirectoryItems)
 	return result or {}
 end

--- a/nativefs.lua
+++ b/nativefs.lua
@@ -392,6 +392,9 @@ local function leaf(p)
 end
 
 function nativefs.getInfo(path, filtertype)
+	if type(path) ~= 'string' then
+		error("bad argument #1 to 'getInfo' (string expected, got " .. type(path) .. ")")
+	end
 	local dir = path:match("(.*[\\/]).*$") or './'
 	local file = leaf(path)
 	local result, err = withTempMount(dir, getInfo, file, filtertype)

--- a/nativefs.lua
+++ b/nativefs.lua
@@ -373,6 +373,9 @@ local function getDirectoryItemsInfo(path, filtertype)
 end
 
 function nativefs.getDirectoryItemsInfo(path, filtertype)
+	if type(path) ~= "string" then
+		error("bad argument #1 to 'getDirectoryItemsInfo' (string expected, got " .. type(path) .. ")")
+	end
 	local result, err = withTempMount(path, getDirectoryItemsInfo, filtertype)
 	return result or {}
 end


### PR DESCRIPTION
This adds some type-checks to ensure path arguments are strings for nativefs.getInfo(), nativefs.getDirectoryItems(), and nativefs.getDirectoryItemsInfo().

The issue with getInfo() is mostly harmless -- it tries to call path:match(), which usually raises an error -- but getDirectoryItems() and getDirectoryItemsInfo() will coredump if passed nil as a path. The equivalents in love.filesystem (sans getDirectoryItemsInfo, which is a nativefs exclusive) all complain if the path isn't a string.

To cause a coredump (tested on Fedora 35 and Windows 10):
-- main.lua
local nativefs = require("path.to.nativefs")
print("before")
local dir_info = nativefs.getDirectoryItems()
print("after")
